### PR TITLE
fix(cursor): add fallback to mcp setup

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,6 @@
+.direnv/
+.envrc
+.github/
+.gitignore
+.vscode/
+Makefile

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "defang-vscode",
+	"name": "defang",
 	"version": "0.1.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "defang-vscode",
+			"name": "defang",
 			"version": "0.1.6",
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -15,7 +15,7 @@
 				"typescript": "^5.8.2"
 			},
 			"engines": {
-				"vscode": "^1.101.0"
+				"vscode": "^1.96.2"
 			}
 		},
 		"node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "defang",
 	"displayName": "Defang",
 	"description": "The easiest way to use Defang in Visual Studio Code",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"publisher": "DefangLabs",
 	"icon": "images/icon.png",
 	"private": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,42 +1,71 @@
-import * as vscode from 'vscode';
+import { exec } from "child_process";
+import * as vscode from "vscode";
 
-export function activate(context: vscode.ExtensionContext) {
-	const appName = vscode.env.appName;
-	const clientId = clientIdForApp(appName);
-	const mcp = vscode.workspace.getConfiguration('mcp');
-	const servers = mcp.get<Record<string, vscode.McpServerDefinition>>('servers', {});
-	if (!servers['defang']) {
-		try {
-			context.subscriptions.push(vscode.lm.registerMcpServerDefinitionProvider('defang', {
-				provideMcpServerDefinitions: async () => {
-					return [new vscode.McpStdioServerDefinition(
-						'Defang',
-						'npx',
-						['-y', 'defang@latest', 'mcp', 'serve', `--client=${clientId}`],
-						{
-							// Environment variables for the Defang MCP server if needed
-							DEFANG_DEBUG: 'false'
-						}
-					)];
-				}
-			}));
-		} catch (error) {
-			console.error('Failed to configure Defang MCP server:', error);
-			vscode.window.showErrorMessage('Failed to configure Defang MCP server. Please try again manually.');
-		}
-	}
+export async function activate(context: vscode.ExtensionContext) {
+  const appName = vscode.env.appName;
+  const clientId = clientIdForApp(appName);
+  const mcp = vscode.workspace.getConfiguration("mcp");
+  const servers = mcp.get<Record<string, vscode.McpServerDefinition>>(
+    "servers",
+    {}
+  );
+  if (!servers["defang"]) {
+    try {
+      context.subscriptions.push(
+        vscode.lm.registerMcpServerDefinitionProvider("defang", {
+          provideMcpServerDefinitions: async () => {
+            return [
+              new vscode.McpStdioServerDefinition(
+                "Defang",
+                "npx",
+                ["-y", "defang@latest", "mcp", "serve", `--client=${clientId}`],
+                {
+                  // Environment variables for the Defang MCP server if needed
+                  DEFANG_DEBUG: "false",
+                }
+              ),
+            ];
+          },
+        })
+      );
+      return;
+    } catch (error) {
+      console.warn("Failed to register Defang MCP server:", error);
+    }
+
+    // Fallback: install our MCP server by running the "setup" command
+    try {
+      const [stdout, stderr] = await new Promise<[string, string]>(
+        (resolve, reject) =>
+          exec(
+            `npx -y defang@latest mcp setup --client="${clientId}"`,
+            (error, stdout, stderr) =>
+              error ? reject(error) : resolve([stdout, stderr])
+          )
+      );
+      console.warn(stdout);
+      if (stderr) {
+        console.error(stderr);
+      }
+    } catch (error) {
+      console.error("Failed to install Defang MCP server:", error);
+      vscode.window.showErrorMessage(
+        "Failed to configure Defang MCP server. Please try again manually."
+      );
+    }
+  }
 }
 
 function clientIdForApp(appName: string): string {
-	switch (appName) {
-		case 'Cursor':
-			return 'cursor';
-		case 'Windsurf':
-			return 'windsurf';
-		case 'Visual Studio Code - Insiders':
-			return 'vscode-insiders';
-		case 'Visual Studio Code':
-			return 'vscode';
-	}
-	return 'vscode';
+  switch (appName) {
+    case "Cursor":
+      return "cursor";
+    case "Windsurf":
+      return "windsurf";
+    case "Visual Studio Code - Insiders":
+      return "vscode-insiders";
+    case "Visual Studio Code":
+      return "vscode";
+  }
+  return "vscode";
 }


### PR DESCRIPTION
On Cursor, registering the Defang MCP server fails, because of https://github.com/cursor/cursor/issues/3549

On error, fall back to legacy `defang mcp setup`.